### PR TITLE
HorizonView: Add circular plane and stick figure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ node_js:
 install: npm install
 script:
 - cd small-angle-demo && make eslint
+- cd ..
 - cd lunar-phase-simulator && make eslint

--- a/lunar-phase-simulator/img/plane.svg
+++ b/lunar-phase-simulator/img/plane.svg
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="128"
+   width="128"
+   version="1.1"
+   id="svg125"
+   sodipodi:docname="plane.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata129">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="2560"
+     inkscape:window-height="1380"
+     id="namedview127"
+     showgrid="false"
+     inkscape:zoom="6.01"
+     inkscape:cx="128.0116"
+     inkscape:cy="100"
+     inkscape:window-x="0"
+     inkscape:window-y="31"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg125" />
+  <g
+     transform="matrix(0.64015977,0,0,0.64,63.983938,64)"
+     id="g113">
+    <use
+       height="200"
+       transform="translate(-99.95,-100)"
+       width="199.95"
+       xlink:href="#shape0"
+       id="use111"
+       x="0"
+       y="0" />
+  </g>
+  <defs
+     id="defs123">
+    <g
+       id="shape0"
+       transform="translate(99.95,100)">
+      <path
+         d="M 70.7,-70.75 Q 100,-41.45 100,0 100,41.4 70.7,70.7 L 64,76.9 Q 36.8,100 0.05,100 -32.15,100 -57,82.35 -64.15,77.25 -70.7,70.7 -100,41.4 -99.95,0 -100,-41.45 -70.7,-70.75 -64.15,-77.3 -57,-82.35 -32.15,-100 0.05,-100 q 36.75,0 63.95,23.1 3.45,2.9 6.7,6.15"
+         id="path115"
+         inkscape:connector-curvature="0"
+         style="fill:url(#gradient0);fill-rule:evenodd;stroke:none" />
+    </g>
+    <radialGradient
+       cx="0"
+       cy="0"
+       gradientTransform="scale(0.1238)"
+       gradientUnits="userSpaceOnUse"
+       id="gradient0"
+       r="819.20001"
+       spreadMethod="pad">
+      <stop
+         offset="0.0"
+         stop-color="#51c451"
+         id="stop118" />
+      <stop
+         offset="1.0"
+         stop-color="#3aa53a"
+         id="stop120" />
+    </radialGradient>
+  </defs>
+</svg>

--- a/lunar-phase-simulator/img/plane.svg
+++ b/lunar-phase-simulator/img/plane.svg
@@ -8,13 +8,16 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   height="128"
-   width="128"
+   height="512"
+   width="512"
    version="1.1"
    id="svg125"
    sodipodi:docname="plane.svg"
    inkscape:version="0.92.3 (2405546, 2018-03-11)"
-   viewBox="0 0 512 512">
+   viewBox="0 0 2048 2048"
+   inkscape:export-filename="/home/nik/public_html/astro-interactives/lunar-phase-simulator/img/plane.svg.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
   <metadata
      id="metadata129">
     <rdf:RDF>
@@ -36,21 +39,20 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1406"
-     inkscape:window-height="978"
+     inkscape:window-width="1967"
+     inkscape:window-height="1236"
      id="namedview127"
      showgrid="false"
-     inkscape:zoom="5.6568543"
-     inkscape:cx="60.702281"
-     inkscape:cy="66.727609"
-     inkscape:window-x="223"
-     inkscape:window-y="174"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="70.517825"
+     inkscape:cy="249.23241"
+     inkscape:window-x="194"
+     inkscape:window-y="70"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg125" />
   <g
-     transform="matrix(2.5606391,0,0,2.56,255.93601,256)"
-     id="g113"
-     style="">
+     transform="matrix(10.242556,0,0,10.24,1023.7443,1024)"
+     id="g113">
     <use
        height="200"
        transform="translate(-99.95,-100)"
@@ -58,8 +60,7 @@
        xlink:href="#shape0"
        id="use111"
        x="0"
-       y="0"
-       style="" />
+       y="0" />
   </g>
   <defs
      id="defs123">
@@ -92,42 +93,44 @@
   </defs>
   <g
      aria-label="N"
-     transform="matrix(4,0,0,4,-4.2864574,0.70710678)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-     id="flowRoot127">
+     transform="matrix(4,0,0,4,-110.375,-64.083261)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot4754">
     <path
-       d="m 67.404948,20.187129 -5.596354,-9.889323 q 0.164062,1.440104 0.164062,2.315104 v 7.574219 H 59.584635 V 7.3446814 h 3.071615 l 5.678385,9.9713536 q -0.164062,-1.376302 -0.164062,-2.50651 V 7.3446814 h 2.38802 V 20.187129 Z"
-       style="fill:#ffffff"
-       id="path4721" />
-  </g>
-  <g
-     aria-label="S"
-     transform="matrix(4,0,0,4,10.153647,13.435029)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-     id="flowRoot135">
-    <path
-       d="m 67.053385,114.4202 q 0,1.88672 -1.403646,2.88932 -1.394531,0.99349 -4.101562,0.99349 -2.470052,0 -3.873698,-0.875 -1.403646,-0.875 -1.804687,-2.65234 l 2.597656,-0.42838 q 0.264323,1.02083 1.029948,1.48567 0.765625,0.45573 2.123698,0.45573 2.816406,0 2.816406,-1.71354 0,-0.54688 -0.328125,-0.90234 -0.319011,-0.35547 -0.911459,-0.59245 -0.583333,-0.23698 -2.251302,-0.57422 -1.440104,-0.33724 -2.005208,-0.53776 -0.565104,-0.20964 -1.020833,-0.48307 -0.455729,-0.28256 -0.77474,-0.67448 -0.31901,-0.39193 -0.501302,-0.92058 -0.173177,-0.52864 -0.173177,-1.21224 0,-1.74088 1.303386,-2.66145 1.312499,-0.92969 3.809895,-0.92969 2.388021,0 3.582031,0.74739 1.203125,0.7474 1.549479,2.47006 l -2.60677,0.35547 q -0.200521,-0.82943 -0.820313,-1.2487 -0.610677,-0.41927 -1.759114,-0.41927 -2.442709,0 -2.442709,1.53125 0,0.5013 0.255209,0.82031 0.264323,0.31901 0.774739,0.54687 0.510417,0.21875 2.069011,0.55599 1.85026,0.39193 2.643229,0.72917 0.802083,0.32813 1.266927,0.77474 0.464844,0.4375 0.710937,1.05729 0.246094,0.61068 0.246094,1.41276 z"
-       style="fill:#ffffff"
-       id="path4715" />
+       d="m 291.59375,87.648283 -19.1875,-33.90625 q 0.5625,4.9375 0.5625,7.9375 v 25.96875 h -8.1875 v -44.03125 h 10.53125 l 19.46875,34.1875 q -0.5625,-4.71875 -0.5625,-8.59375 v -25.59375 h 8.1875 v 44.03125 z"
+       style="font-size:64px;fill:#ffffff"
+       id="path4792"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      aria-label="E"
-     transform="matrix(4,0,0,4,8.4852817,-2.7042455)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-     id="flowRoot143">
+     transform="matrix(4,0,0,4,223.44574,173.46937)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot4762">
     <path
-       d="M 109.61198,71.097285 V 58.254838 h 10.09896 v 2.078125 h -7.41016 v 3.226562 h 6.85417 v 2.078125 h -6.85417 v 3.38151 h 7.78386 v 2.078125 z"
-       style="fill:#ffffff"
-       id="path4718" />
+       d="m 392.28125,234.64828 v -44.03125 h 34.625 v 7.125 H 401.5 v 11.0625 H 425 v 7.125 h -23.5 v 11.59375 h 26.6875 v 7.125 z"
+       style="font-size:64px;fill:#ffffff"
+       id="path4795" />
+  </g>
+  <g
+     aria-label="S"
+     transform="matrix(4,0,0,4,79.9375,26.343146)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot4770">
+    <path
+       d="m 255.1875,463.96078 q 0,6.46875 -4.8125,9.90625 -4.78125,3.40625 -14.0625,3.40625 -8.46875,0 -13.28125,-3 -4.8125,-3 -6.1875,-9.09375 l 8.90625,-1.46875 q 0.90625,3.5 3.53125,5.09375 2.625,1.5625 7.28125,1.5625 9.65625,0 9.65625,-5.875 0,-1.875 -1.125,-3.09375 -1.09375,-1.21875 -3.125,-2.03125 -2,-0.8125 -7.71875,-1.96875 -4.9375,-1.15625 -6.875,-1.84375 -1.9375,-0.71875 -3.5,-1.65625 -1.5625,-0.96875 -2.65625,-2.3125 -1.09375,-1.34375 -1.71875,-3.15625 -0.59375,-1.8125 -0.59375,-4.15625 0,-5.96875 4.46875,-9.125 4.5,-3.1875 13.0625,-3.1875 8.1875,0 12.28125,2.5625 4.125,2.5625 5.3125,8.46875 l -8.9375,1.21875 q -0.6875,-2.84375 -2.8125,-4.28125 -2.09375,-1.4375 -6.03125,-1.4375 -8.375,0 -8.375,5.25 0,1.71875 0.875,2.8125 0.90625,1.09375 2.65625,1.875 1.75,0.75 7.09375,1.90625 6.34375,1.34375 9.0625,2.5 2.75,1.125 4.34375,2.65625 1.59375,1.5 2.4375,3.625 0.84375,2.09375 0.84375,4.84375 z"
+       style="font-size:64px;fill:#ffffff"
+       id="path4789"
+       inkscape:connector-curvature="0" />
   </g>
   <g
      aria-label="W"
-     transform="matrix(4,0,0,4,11.313708,-6.243308)"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-     id="flowRoot151">
+     transform="matrix(4,0,0,4,8,11.469368)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:32px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot4778">
     <path
-       d="m 17.288411,71.982051 h -3.190104 l -1.740885,-7.428385 q -0.319011,-1.3125 -0.537761,-2.74349 -0.21875,1.19401 -0.355469,1.822917 -0.136718,0.619791 -1.9414058,8.348958 H 6.3326822 L 3.0240885,59.139603 h 2.7252604 l 1.8593749,8.294271 0.4192708,2.005208 q 0.2552083,-1.266927 0.4921875,-2.415364 0.2460937,-1.157552 1.8229169,-7.884115 h 3.007812 l 1.622396,6.835938 q 0.191406,0.765624 0.647135,3.463541 l 0.227865,-1.057292 0.483073,-2.096354 1.549479,-7.145833 h 2.72526 z"
-       style="fill:#ffffff"
-       id="path4712" />
+       d="M 69.96875,275.14828 H 59.03125 L 53.0625,249.67953 q -1.09375,-4.5 -1.84375,-9.40625 -0.75,4.09375 -1.21875,6.25 -0.46875,2.125 -6.65625,28.625 H 32.40625 L 21.0625,231.11703 h 9.34375 l 6.375,28.4375 1.4375,6.875 q 0.875,-4.34375 1.6875,-8.28125 0.84375,-3.96875 6.25,-27.03125 h 10.3125 l 5.5625,23.4375 q 0.65625,2.625 2.21875,11.875 l 0.78125,-3.625 1.65625,-7.1875 5.3125,-24.5 h 9.34375 z"
+       style="font-size:64px;fill:#ffffff"
+       id="path4786" />
   </g>
 </svg>

--- a/lunar-phase-simulator/img/plane.svg
+++ b/lunar-phase-simulator/img/plane.svg
@@ -13,7 +13,8 @@
    version="1.1"
    id="svg125"
    sodipodi:docname="plane.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   viewBox="0 0 512 512">
   <metadata
      id="metadata129">
     <rdf:RDF>
@@ -35,20 +36,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="2560"
-     inkscape:window-height="1380"
+     inkscape:window-width="1406"
+     inkscape:window-height="978"
      id="namedview127"
      showgrid="false"
-     inkscape:zoom="6.01"
-     inkscape:cx="128.0116"
-     inkscape:cy="100"
-     inkscape:window-x="0"
-     inkscape:window-y="31"
-     inkscape:window-maximized="1"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="60.702281"
+     inkscape:cy="66.727609"
+     inkscape:window-x="223"
+     inkscape:window-y="174"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg125" />
   <g
-     transform="matrix(0.64015977,0,0,0.64,63.983938,64)"
-     id="g113">
+     transform="matrix(2.5606391,0,0,2.56,255.93601,256)"
+     id="g113"
+     style="">
     <use
        height="200"
        transform="translate(-99.95,-100)"
@@ -56,7 +58,8 @@
        xlink:href="#shape0"
        id="use111"
        x="0"
-       y="0" />
+       y="0"
+       style="" />
   </g>
   <defs
      id="defs123">
@@ -87,4 +90,44 @@
          id="stop120" />
     </radialGradient>
   </defs>
+  <g
+     aria-label="N"
+     transform="matrix(4,0,0,4,-4.2864574,0.70710678)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot127">
+    <path
+       d="m 67.404948,20.187129 -5.596354,-9.889323 q 0.164062,1.440104 0.164062,2.315104 v 7.574219 H 59.584635 V 7.3446814 h 3.071615 l 5.678385,9.9713536 q -0.164062,-1.376302 -0.164062,-2.50651 V 7.3446814 h 2.38802 V 20.187129 Z"
+       style="fill:#ffffff"
+       id="path4721" />
+  </g>
+  <g
+     aria-label="S"
+     transform="matrix(4,0,0,4,10.153647,13.435029)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot135">
+    <path
+       d="m 67.053385,114.4202 q 0,1.88672 -1.403646,2.88932 -1.394531,0.99349 -4.101562,0.99349 -2.470052,0 -3.873698,-0.875 -1.403646,-0.875 -1.804687,-2.65234 l 2.597656,-0.42838 q 0.264323,1.02083 1.029948,1.48567 0.765625,0.45573 2.123698,0.45573 2.816406,0 2.816406,-1.71354 0,-0.54688 -0.328125,-0.90234 -0.319011,-0.35547 -0.911459,-0.59245 -0.583333,-0.23698 -2.251302,-0.57422 -1.440104,-0.33724 -2.005208,-0.53776 -0.565104,-0.20964 -1.020833,-0.48307 -0.455729,-0.28256 -0.77474,-0.67448 -0.31901,-0.39193 -0.501302,-0.92058 -0.173177,-0.52864 -0.173177,-1.21224 0,-1.74088 1.303386,-2.66145 1.312499,-0.92969 3.809895,-0.92969 2.388021,0 3.582031,0.74739 1.203125,0.7474 1.549479,2.47006 l -2.60677,0.35547 q -0.200521,-0.82943 -0.820313,-1.2487 -0.610677,-0.41927 -1.759114,-0.41927 -2.442709,0 -2.442709,1.53125 0,0.5013 0.255209,0.82031 0.264323,0.31901 0.774739,0.54687 0.510417,0.21875 2.069011,0.55599 1.85026,0.39193 2.643229,0.72917 0.802083,0.32813 1.266927,0.77474 0.464844,0.4375 0.710937,1.05729 0.246094,0.61068 0.246094,1.41276 z"
+       style="fill:#ffffff"
+       id="path4715" />
+  </g>
+  <g
+     aria-label="E"
+     transform="matrix(4,0,0,4,8.4852817,-2.7042455)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot143">
+    <path
+       d="M 109.61198,71.097285 V 58.254838 h 10.09896 v 2.078125 h -7.41016 v 3.226562 h 6.85417 v 2.078125 h -6.85417 v 3.38151 h 7.78386 v 2.078125 z"
+       style="fill:#ffffff"
+       id="path4718" />
+  </g>
+  <g
+     aria-label="W"
+     transform="matrix(4,0,0,4,11.313708,-6.243308)"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18.66666603px;line-height:1.25;font-family:'Liberation Sans';-inkscape-font-specification:'Liberation Sans Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+     id="flowRoot151">
+    <path
+       d="m 17.288411,71.982051 h -3.190104 l -1.740885,-7.428385 q -0.319011,-1.3125 -0.537761,-2.74349 -0.21875,1.19401 -0.355469,1.822917 -0.136718,0.619791 -1.9414058,8.348958 H 6.3326822 L 3.0240885,59.139603 h 2.7252604 l 1.8593749,8.294271 0.4192708,2.005208 q 0.2552083,-1.266927 0.4921875,-2.415364 0.2460937,-1.157552 1.8229169,-7.884115 h 3.007812 l 1.622396,6.835938 q 0.191406,0.765624 0.647135,3.463541 l 0.227865,-1.057292 0.483073,-2.096354 1.549479,-7.145833 h 2.72526 z"
+       style="fill:#ffffff"
+       id="path4712" />
+  </g>
 </svg>

--- a/lunar-phase-simulator/img/stickfigure.svg
+++ b/lunar-phase-simulator/img/stickfigure.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="32"
+   width="16"
+   version="1.1"
+   id="svg274"
+   sodipodi:docname="stickfigure.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata278">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1648"
+     inkscape:window-height="832"
+     id="namedview276"
+     showgrid="false"
+     inkscape:zoom="7.707954"
+     inkscape:cx="24.71803"
+     inkscape:cy="17.93599"
+     inkscape:window-x="506"
+     inkscape:window-y="322"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg274" />
+  <g
+     transform="matrix(1.4771383,0,0,1.4771383,8.0001701,30.516413)"
+     id="g263">
+    <use
+       height="21.65"
+       transform="translate(-4.6,-20.65)"
+       width="9.1999998"
+       xlink:href="#shape0"
+       id="use261"
+       x="0"
+       y="0" />
+  </g>
+  <defs
+     id="defs272">
+    <g
+       id="shape0"
+       transform="translate(4.6,20.65)">
+      <path
+         d="m 1.3,-16.2 q -0.6,0.55 -1.4,0.6 -0.85,-0.05 -1.4,-0.6 -0.6,-0.6 -0.6,-1.45 0,-0.85 0.6,-1.4 0.55,-0.6 1.4,-0.6 0.8,0 1.4,0.6 0.6,0.55 0.6,1.4 0,0.85 -0.6,1.45"
+         id="path265"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-rule:evenodd;stroke:none" />
+      <path
+         d="m 1.3,-16.2 q -0.6,0.55 -1.4,0.6 -0.85,-0.05 -1.4,-0.6 -0.6,-0.6 -0.6,-1.45 0,-0.85 0.6,-1.4 0.55,-0.6 1.4,-0.6 0.8,0 1.4,0.6 0.6,0.55 0.6,1.4 0,0.85 -0.6,1.45 m -0.85,3 3.15,1.5 m -3.7,-1.5 -3.5,1.5 m 3.5,2.9 3.15,8.8 m -6.2,0 3,-8.95 0.05,0.15"
+         id="path267"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#333333;stroke-width:2;stroke-linecap:round;stroke-linejoin:round" />
+      <path
+         d="m -0.1,-14.75 v 1.55 4.4"
+         id="path269"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#333333;stroke-width:2;stroke-linecap:round;stroke-linejoin:round" />
+    </g>
+  </defs>
+</svg>

--- a/lunar-phase-simulator/package-lock.json
+++ b/lunar-phase-simulator/package-lock.json
@@ -2877,7 +2877,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3242,7 +3243,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3290,6 +3292,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3328,11 +3331,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -8,6 +8,7 @@ export default class HorizonView extends React.Component {
     constructor(props) {
         super(props)
 
+        this.id = 'HorizonView';
         this.start = this.start.bind(this)
         this.stop = this.stop.bind(this)
         this.animate = this.animate.bind(this)
@@ -24,14 +25,21 @@ export default class HorizonView extends React.Component {
             0.1,
             1000
         )
-        //const controls = new THREE.OrbitControls(camera);
+        const controls = new THREE.OrbitControls(
+            camera, document.getElementById(this.id));
+        // Configure the controls - we only need some basic
+        // drag-rotation behavior.
+        controls.enableKeys = false;
+        controls.enablePan = false;
+        controls.enableZoom = false;
+
         const renderer = new THREE.WebGLRenderer({ antialias: true })
         const geometry = new THREE.BoxGeometry(1, 1, 1)
         const material = new THREE.MeshBasicMaterial({ color: '#433F81' })
         const cube = new THREE.Mesh(geometry, material)
 
         camera.position.z = 4
-        //controls.update();
+        controls.update();
         scene.add(cube)
         renderer.setClearColor('#000000')
         renderer.setSize(width, height)
@@ -75,10 +83,9 @@ export default class HorizonView extends React.Component {
 
     render() {
         return (
-            <div
-                style={{ width: '228px', height: '228px' }}
-                ref={(mount) => { this.mount = mount }}
-            />
-        )
+            <div id={this.id}
+                 style={{ width: '228px', height: '228px' }}
+                 ref={(mount) => { this.mount = mount }} />
+        );
     }
 }

--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -9,59 +9,86 @@ export default class HorizonView extends React.Component {
         super(props)
 
         this.id = 'HorizonView';
-        this.start = this.start.bind(this)
-        this.stop = this.stop.bind(this)
-        this.animate = this.animate.bind(this)
+        this.start = this.start.bind(this);
+        this.stop = this.stop.bind(this);
+        this.animate = this.animate.bind(this);
     }
 
     componentDidMount() {
-        const width = this.mount.clientWidth
-        const height = this.mount.clientHeight
+        const width = this.mount.clientWidth;
+        const height = this.mount.clientHeight;
 
-        const scene = new THREE.Scene()
+        const scene = new THREE.Scene();
         const camera = new THREE.PerspectiveCamera(
             75,
             width / height,
             0.1,
             1000
-        )
-        const controls = new THREE.OrbitControls(
-            camera, document.getElementById(this.id));
+        );
+        const controls = new THREE.OrbitControls(camera, this.mount);
         // Configure the controls - we only need some basic
         // drag-rotation behavior.
         controls.enableKeys = false;
         controls.enablePan = false;
         controls.enableZoom = false;
 
-        const renderer = new THREE.WebGLRenderer({ antialias: true })
-        const geometry = new THREE.BoxGeometry(1, 1, 1)
-        const material = new THREE.MeshBasicMaterial({ color: '#433F81' })
-        const cube = new THREE.Mesh(geometry, material)
+        // Only let the user see the top of the scene - no need to
+        // flip it completely over.
+        controls.minPolarAngle = Math.PI / 4;
+        controls.maxPolarAngle = Math.PI - 1.2;
 
-        camera.position.z = 4
+        // Don't rotate on the side-to-side axis. For this mouse
+        // movement, the plane must be rotated on its own axis.
+        controls.minAzimuthAngle = 0;
+        controls.maxAzimuthAngle = 0;
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+
+        camera.position.z = 8;
         controls.update();
-        scene.add(cube)
-        renderer.setClearColor('#000000')
-        renderer.setSize(width, height)
+        renderer.setClearColor(0xffffff);
+        renderer.setSize(width, height);
 
-        this.scene = scene
-        this.camera = camera
-        this.renderer = renderer
-        this.material = material
-        this.cube = cube
+        // Draw horizon
+        const texture = new THREE.TextureLoader().load('img/plane.svg');
+        const material = new THREE.MeshBasicMaterial({
+            transparent: true,
+            map: texture,
+            side: THREE.DoubleSide
+        });
+        const geometry = new THREE.CircleGeometry(5, 64);
+        const plane = new THREE.Mesh(geometry, material);
+        plane.rotation.x = -1;
+        scene.add(plane);
 
-        this.mount.appendChild(this.renderer.domElement)
-        this.start()
+        // Draw stick figure
+        const spriteMap = new THREE.TextureLoader().load('img/stickfigure.svg');
+        const spriteMaterial = new THREE.SpriteMaterial({
+            map: spriteMap,
+            color: 0xffffff
+        });
+        const sprite = new THREE.Sprite(spriteMaterial);
+        sprite.scale.set(1, 2, 1);
+        sprite.position.y = 1;
+        scene.add(sprite);
+
+        this.scene = scene;
+        this.camera = camera;
+        this.renderer = renderer;
+        this.material = material;
+
+        this.mount.appendChild(this.renderer.domElement);
+        this.start();
     }
 
     componentWillUnmount() {
-        this.stop()
-        this.mount.removeChild(this.renderer.domElement)
+        this.stop();
+        this.mount.removeChild(this.renderer.domElement);
     }
 
     start() {
         if (!this.frameId) {
-            this.frameId = requestAnimationFrame(this.animate)
+            this.frameId = requestAnimationFrame(this.animate);
         }
     }
 
@@ -70,15 +97,12 @@ export default class HorizonView extends React.Component {
     }
 
     animate() {
-        this.cube.rotation.x += 0.01
-        this.cube.rotation.y += 0.01
-
-        this.renderScene()
-        this.frameId = window.requestAnimationFrame(this.animate)
+        this.renderScene();
+        this.frameId = window.requestAnimationFrame(this.animate);
     }
 
     renderScene() {
-        this.renderer.render(this.scene, this.camera)
+        this.renderer.render(this.scene, this.camera);
     }
 
     render() {

--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -30,7 +30,7 @@ export default class HorizonView extends React.Component {
         // drag-rotation behavior.
         controls.enableKeys = false;
         controls.enablePan = false;
-        controls.enableZoom = false;
+        //controls.enableZoom = false;
 
         // Only let the user see the top of the scene - no need to
         // flip it completely over.
@@ -63,7 +63,7 @@ export default class HorizonView extends React.Component {
     }
     drawPlane(scene) {
         const texture = new THREE.TextureLoader().load('img/plane.svg');
-        texture.mapping = THREE.UVMapping;
+
         const material = new THREE.MeshBasicMaterial({
             transparent: true,
             map: texture,
@@ -72,7 +72,6 @@ export default class HorizonView extends React.Component {
         material.map.minFilter = THREE.LinearFilter;
         const geometry = new THREE.CircleGeometry(5, 64);
         const plane = new THREE.Mesh(geometry, material);
-        //plane.scale.set(1000, 1000, 1);
         plane.rotation.x = -1;
         scene.add(plane);
     }

--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -61,16 +61,8 @@ export default class HorizonView extends React.Component {
         plane.rotation.x = -1;
         scene.add(plane);
 
-        // Draw stick figure
-        const spriteMap = new THREE.TextureLoader().load('img/stickfigure.svg');
-        const spriteMaterial = new THREE.SpriteMaterial({
-            map: spriteMap,
-            color: 0xffffff
-        });
-        const sprite = new THREE.Sprite(spriteMaterial);
-        sprite.scale.set(1, 2, 1);
-        sprite.position.y = 1;
-        scene.add(sprite);
+        //this.drawGlobe(scene);
+        this.drawStickFigure(scene);
 
         this.scene = scene;
         this.camera = camera;
@@ -80,7 +72,27 @@ export default class HorizonView extends React.Component {
         this.mount.appendChild(this.renderer.domElement);
         this.start();
     }
-
+    drawGlobe(scene) {
+        const geometry = new THREE.SphereGeometry(4.9, 32, 32);
+        const material = new THREE.MeshBasicMaterial({
+            transparent: true,
+            opacity: 0.2,
+            color: 0x0000ff
+        });
+        const sphere = new THREE.Mesh(geometry, material);
+        scene.add( sphere );
+    }
+    drawStickFigure(scene) {
+        const spriteMap = new THREE.TextureLoader().load('img/stickfigure.svg');
+        const spriteMaterial = new THREE.SpriteMaterial({
+            map: spriteMap,
+            color: 0xffffff
+        });
+        const sprite = new THREE.Sprite(spriteMaterial);
+        sprite.scale.set(1, 2, 1);
+        sprite.position.y = 1;
+        scene.add(sprite);
+    }
     componentWillUnmount() {
         this.stop();
         this.mount.removeChild(this.renderer.domElement);

--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -43,34 +43,38 @@ export default class HorizonView extends React.Component {
         controls.maxAzimuthAngle = 0;
 
         const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
 
         camera.position.z = 8;
         controls.update();
         renderer.setClearColor(0xffffff);
         renderer.setSize(width, height);
 
-        // Draw horizon
-        const texture = new THREE.TextureLoader().load('img/plane.svg');
-        const material = new THREE.MeshBasicMaterial({
-            transparent: true,
-            map: texture,
-            side: THREE.DoubleSide
-        });
-        const geometry = new THREE.CircleGeometry(5, 64);
-        const plane = new THREE.Mesh(geometry, material);
-        plane.rotation.x = -1;
-        scene.add(plane);
-
+        this.drawPlane(scene);
         //this.drawGlobe(scene);
         this.drawStickFigure(scene);
 
         this.scene = scene;
         this.camera = camera;
         this.renderer = renderer;
-        this.material = material;
 
         this.mount.appendChild(this.renderer.domElement);
         this.start();
+    }
+    drawPlane(scene) {
+        const texture = new THREE.TextureLoader().load('img/plane.svg');
+        texture.mapping = THREE.UVMapping;
+        const material = new THREE.MeshBasicMaterial({
+            transparent: true,
+            map: texture,
+            side: THREE.DoubleSide
+        });
+        material.map.minFilter = THREE.LinearFilter;
+        const geometry = new THREE.CircleGeometry(5, 64);
+        const plane = new THREE.Mesh(geometry, material);
+        //plane.scale.set(1000, 1000, 1);
+        plane.rotation.x = -1;
+        scene.add(plane);
     }
     drawGlobe(scene) {
         const geometry = new THREE.SphereGeometry(4.9, 32, 32);

--- a/lunar-phase-simulator/src/MoonPhaseView.jsx
+++ b/lunar-phase-simulator/src/MoonPhaseView.jsx
@@ -9,7 +9,7 @@ export default class MoonPhaseView extends React.Component {
     }
     render() {
         return <div>
-            <select className="custom-select" defaultValue={1}>
+            <select className="custom-select form-control-sm" defaultValue={1}>
                 <option value={1}>New Moon</option>
                 <option value={2}>Waxing Crescent</option>
                 <option value={3}>First Quarter</option>


### PR DESCRIPTION
I wanted to do this 3D part first since I haven't made a globe-type thing in Three.js before. I have the circular plane showing and a stick figure. Here's what I need to do next:

* Overlay the N/W/S/E compass on the plane
* Display a globe around the circular plane with lines around it
* Rotate the globe when the mouse moves right-to-left. I thought that OrbitControls would handle this, but OrbitControls rotates *around* the plane, which isn't what's needed. But I am able to use OrbitControls functionality for the up-and-down mouse motion.
* Currently the stick figure is a [Sprite](https://threejs.org/docs/index.html#api/objects/Sprite), i.e. always faces the camera. But the third dimension does need to be seen when the camera moves up. In [the original](https://cse.unl.edu/~astrodev/flashdev2/lunar_applet/lunar_applet040.html), the stick figure is sort of a half-sprite: always faces the camera when spinning the globe, but shows perspective when the camera moves up.