### PR TITLE
Add dev notes for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here are instructions on how to develop and make changes to these interactives.
 The procedure above relies on [make](https://www.gnu.org/software/make/), a pretty typical unix utility on Linux and Mac. So, you can either get that working on Windows, or you can just go without it with the following steps:
 * Install [node.js](https://nodejs.org/en/)
 * Clone this repository
-* Go into one of the interactives, e.g.: `cd astro-interactives/lunar-phase-simulator`
+* Go into one of the interactives, e.g.: `cd astro-interactives\lunar-phase-simulator`
 * Run `npm install`
 * Run `.\node_modules\.bin\webpack --mode development --watch`
 * Open the `lunar-phase-simulator\index.html` file in your web browser.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,18 @@ JavaScript/HTML ports of the Flash originals, found here: [http://astro.unl.edu/
 
 Here are instructions on how to develop and make changes to these interactives.
 
+### macOS / Linux 
 * Install [node.js](https://nodejs.org/en/)
 * Clone this repository
 * Go into one of the interactives, e.g.: `cd astro-interactives/lunar-phase-simulator`
 * Run `make dev`
 * Open the `lunar-phase-simulator/index.html` file in your web browser.
+
+### Windows
+The procedure above relies on [make](https://www.gnu.org/software/make/), a pretty typical unix utility on Linux and Mac. So, you can either get that working on Windows, or you can just go without it with the following steps:
+* Install [node.js](https://nodejs.org/en/)
+* Clone this repository
+* Go into one of the interactives, e.g.: `cd astro-interactives/lunar-phase-simulator`
+* Run `npm install`
+* Run `.\node_modules\.bin\webpack --mode development --watch`
+* Open the `lunar-phase-simulator\index.html` file in your web browser.


### PR DESCRIPTION
`make` isn't around by default on Windows, but node/webpack/etc all work fine, so I've added some alternative instructions.