### PR TITLE
Use Torus instead of lines

### DIFF
--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -136,37 +136,35 @@ export default class HorizonView extends React.Component {
         const dayDome = new THREE.Mesh(domeGeometry, this.skyMaterial);
         scene.add(dayDome);
 
-        const lineMaterial = new THREE.LineBasicMaterial({
+        const lineMeshMaterial = new THREE.MeshBasicMaterial({
             transparent: true,
             opacity: 0.5,
-            color: 0xffffff,
-            linewidth: 4
+            color: 0xffffff
         });
 
-        // The EdgesGeometry is necessary to fix a problem when
-        // drawing lines on CircleGeometry.
-        // https://stackoverflow.com/q/51525988/173630
-        const discGeometry = new THREE.EdgesGeometry(
-            new THREE.CircleBufferGeometry(50, 64));
+        const thinTorusGeometry = new THREE.TorusBufferGeometry(
+            50, 0.1, 16, 64);
 
         // A north-south line
-        const observersMeridian = new THREE.LineSegments(
-            discGeometry, lineMaterial);
+        const observersMeridian = new THREE.Mesh(
+            thinTorusGeometry, lineMeshMaterial);
         observersMeridian.rotation.y = THREE.Math.degToRad(90);
         scene.add(observersMeridian);
 
         // An east-west line at the top of the observer's globe
-        const zenithEquator = new THREE.LineSegments(discGeometry, lineMaterial);
+        const zenithEquator = new THREE.Mesh(
+            thinTorusGeometry, lineMeshMaterial);
         zenithEquator.rotation.z = THREE.Math.degToRad(90);
         scene.add(zenithEquator);
 
         // The sun and moon orbit along this next line.
-        const thickLineMaterial = new THREE.LineBasicMaterial({
-            color: 0xffffff,
-            linewidth: 8
+        const solidLineMaterial = new THREE.MeshBasicMaterial({
+            color: 0xffffff
         });
-        this.celestialEquator = new THREE.LineSegments(
-            discGeometry, thickLineMaterial);
+        const thickTorusGeometry = new THREE.TorusBufferGeometry(
+            50, 0.3, 16, 64);
+        this.celestialEquator = new THREE.Mesh(
+            thickTorusGeometry, solidLineMaterial);
         this.celestialEquator.rotation.x = THREE.Math.degToRad(90);
     }
     drawStickFigure(scene) {

--- a/sun-motion-simulator/package-lock.json
+++ b/sun-motion-simulator/package-lock.json
@@ -3925,11 +3925,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3942,15 +3944,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4053,7 +4058,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4063,6 +4069,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4075,17 +4082,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4102,6 +4112,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4174,7 +4185,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4184,6 +4196,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4289,6 +4302,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/sun-motion-simulator/src/HorizonView.jsx
+++ b/sun-motion-simulator/src/HorizonView.jsx
@@ -157,64 +157,58 @@ export default class HorizonView extends React.Component {
         const dayDome = new THREE.Mesh(domeGeometry, this.skyMaterial);
         scene.add(dayDome);
 
-        const lineMaterial = new THREE.LineBasicMaterial({
+        const lineMeshMaterial = new THREE.MeshBasicMaterial({
             transparent: true,
             opacity: 0.5,
-            color: 0xffffff,
-            linewidth: 2
+            color: 0xffffff
         });
 
-        // The EdgesGeometry is necessary to fix a problem when
-        // drawing lines on CircleGeometry.
-        // https://stackoverflow.com/q/51525988/173630
-        const discGeometry = new THREE.EdgesGeometry(
-            new THREE.CircleBufferGeometry(50, 64));
+        const thinTorusGeometry = new THREE.TorusBufferGeometry(
+            50, 0.1, 16, 64);
 
         // A north-south line
-        const observersMeridian = new THREE.LineSegments(
-            discGeometry, lineMaterial);
+        const observersMeridian = new THREE.Mesh(
+            thinTorusGeometry, lineMeshMaterial);
         observersMeridian.rotation.y = THREE.Math.degToRad(90);
         scene.add(observersMeridian);
 
         // An east-west line at the top of the observer's globe
-        const zenithEquator = new THREE.LineSegments(discGeometry, lineMaterial);
+        const zenithEquator = new THREE.Mesh(thinTorusGeometry, lineMeshMaterial);
         zenithEquator.rotation.z = THREE.Math.degToRad(90);
         scene.add(zenithEquator);
 
         // The sun orbits along this next line.
-        const yellowMaterial = new THREE.LineBasicMaterial({
-            color: 0xffff00,
-            linewidth: 8
+        const yellowMaterial = new THREE.MeshBasicMaterial({
+            color: 0xffff00
         });
 
-        const declinationGeometry = new THREE.EdgesGeometry(
-            new THREE.CircleBufferGeometry(46, 64));
-        this.sunDeclination = new THREE.LineSegments(
-            declinationGeometry, yellowMaterial);
+        const declinationGeometry = new THREE.TorusBufferGeometry(46, 0.3, 16, 64);
+        this.sunDeclination = new THREE.Mesh(declinationGeometry, yellowMaterial);
         this.sunDeclination.position.y = 20;
         this.sunDeclination.rotation.x = THREE.Math.degToRad(90);
 
-        const blueMaterial = new THREE.LineBasicMaterial({
-            color: 0x7080ff,
-            linewidth: 8
+        const thickTorusGeometry = new THREE.TorusBufferGeometry(
+            50, 0.3, 16, 64);
+        const blueMaterial = new THREE.MeshBasicMaterial({
+            color: 0x7080ff
         });
-        this.celestialEquator = new THREE.LineSegments(
-            discGeometry, blueMaterial);
+        this.celestialEquator = new THREE.Mesh(
+            thickTorusGeometry, blueMaterial);
         this.celestialEquator.rotation.x = THREE.Math.degToRad(90);
 
-        const primeHourGeometry = new THREE.EdgesGeometry(
-            new THREE.CircleBufferGeometry(50, 64, 0, Math.PI));
-        this.primeHourCircle = new THREE.LineSegments(
+        /*const primeHourGeometry = new THREE.EdgesGeometry(
+            new THREE.CircleBufferGeometry(50, 64, 0, Math.PI));*/
+        const primeHourGeometry = new THREE.TorusBufferGeometry(
+            50, 0.3, 16, 64, Math.PI);
+        this.primeHourCircle = new THREE.Mesh(
             primeHourGeometry, blueMaterial);
         this.primeHourCircle.rotation.z = THREE.Math.degToRad(90);
         this.primeHourCircle.rotation.y = THREE.Math.degToRad(180 + 45);
 
-        const thickWhiteMaterial = new THREE.LineBasicMaterial({
-            color: 0xffffff,
-            linewidth: 8
+        const whiteMaterial = new THREE.MeshBasicMaterial({
+            color: 0xffffff
         });
-        this.ecliptic = new THREE.LineSegments(
-            discGeometry, thickWhiteMaterial);
+        this.ecliptic = new THREE.Mesh(thickTorusGeometry, whiteMaterial);
         this.ecliptic.rotation.x = THREE.Math.degToRad(90 + 24);
         this.ecliptic.rotation.y = THREE.Math.degToRad(-12);
     }


### PR DESCRIPTION
This fixes inconsistent line rendering on different systems.

See:
* https://mattdesl.svbtle.com/drawing-lines-is-hard
* https://stackoverflow.com/a/41911520/173630

[THREE.MeshLine](https://github.com/spite/THREE.MeshLine) is one
workaround for this, but for these particular lines I can get by with
just using the Torus construct already included in three.js. This is
better anyways because I've seen some shader errors when using
THREE.MeshLine - it's not quite up to date with upstream three.js.