### PR TITLE
transit simulator: Introduce pixi-viewport + make the phase slider work

### DIFF
--- a/exoplanet-transit-simulator/package-lock.json
+++ b/exoplanet-transit-simulator/package-lock.json
@@ -4252,11 +4252,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4269,15 +4271,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4380,7 +4385,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4390,6 +4396,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4402,17 +4409,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4429,6 +4439,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4501,7 +4512,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4511,6 +4523,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4616,6 +4629,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/exoplanet-transit-simulator/package-lock.json
+++ b/exoplanet-transit-simulator/package-lock.json
@@ -4252,13 +4252,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4271,18 +4269,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4385,8 +4380,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4396,7 +4390,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4409,20 +4402,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4439,7 +4429,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4512,8 +4501,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4523,7 +4511,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4629,7 +4616,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8045,6 +8031,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "penner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/penner/-/penner-0.1.3.tgz",
+      "integrity": "sha1-C4tILU6bOa8vPXw3WSIpuKzClwU="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -8076,6 +8067,22 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.4.tgz",
       "integrity": "sha1-i0tcQzsx5Bm8N53FZc4bg1qRs3I="
+    },
+    "pixi-viewport": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-3.4.1.tgz",
+      "integrity": "sha512-UfF+pLEE063dFu63IMlGiOauYOcGGUxLICUHDk+Xb69gEIT8pNWhJtCTDIwa/V0J6xovpPmAG6Bto2yH6dhqaQ==",
+      "requires": {
+        "eventemitter3": "^3.1.0",
+        "penner": "^0.1.3"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
+          "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA=="
+        }
+      }
     },
     "pixi.js": {
       "version": "4.8.1",

--- a/exoplanet-transit-simulator/package-lock.json
+++ b/exoplanet-transit-simulator/package-lock.json
@@ -2619,6 +2619,15 @@
       "integrity": "sha512-G2cDhHp0DshhwFJSurN7PByRTXgijs3eA3F9tGd5tf5vnTttDVuRI9bFna0WDMID4VYhGs2ob9U/K1A5+pm8pw==",
       "dev": true
     },
+    "canvas": {
+      "version": "1.3.16",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-1.3.16.tgz",
+      "integrity": "sha1-fr3oxU0Jj7Wbm1mPlMkI9uk5FH0=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.3.2"
+      }
+    },
     "capture-exit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
@@ -4252,13 +4261,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4271,18 +4278,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4385,8 +4389,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4396,7 +4399,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4409,20 +4411,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4439,7 +4438,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4512,8 +4510,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4523,7 +4520,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4629,7 +4625,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6669,6 +6664,15 @@
         "array-includes": "^3.0.3"
       }
     },
+    "jsxgraph": {
+      "version": "0.99.7",
+      "resolved": "https://registry.npmjs.org/jsxgraph/-/jsxgraph-0.99.7.tgz",
+      "integrity": "sha1-V+Ss7ydek3bpK91mcoNNl2VN4lY=",
+      "requires": {
+        "canvas": "1.3.x",
+        "requirejs": "2.3.x"
+      }
+    },
     "keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
@@ -8702,6 +8706,11 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requirejs": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+      "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
     },
     "resolve": {
       "version": "1.1.7",

--- a/exoplanet-transit-simulator/package.json
+++ b/exoplanet-transit-simulator/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/ccnmtl/astro-interactives#readme",
   "dependencies": {
     "babel-cli": "^6.26.0",
+    "jsxgraph": "^0.99.7",
     "pixi-viewport": "^3.4.1",
     "pixi.js": "^4.8.1",
     "react": "^16.4.1",

--- a/exoplanet-transit-simulator/package.json
+++ b/exoplanet-transit-simulator/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/ccnmtl/astro-interactives#readme",
   "dependencies": {
     "babel-cli": "^6.26.0",
+    "pixi-viewport": "^3.4.1",
     "pixi.js": "^4.8.1",
     "react": "^16.4.1",
     "react-dom": "^16.4.1"

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -25,10 +25,7 @@ export default class LightcurveView extends React.Component {
             worldHeight: 500 * (220 / 400)
         });
         this.viewport = viewport;
-        this.viewport
-            .drag()
-            .wheel()
-            .zoom();
+        this.viewport.zoom();
 
         const app = new PIXI.Application({
             backgroundColor: 0xffffff,
@@ -55,6 +52,7 @@ export default class LightcurveView extends React.Component {
         line.position.set(x, y);
         line.width = width;
         line.height = height;
+        return line;
     }
 
     drawBorder(viewport) {
@@ -75,11 +73,11 @@ export default class LightcurveView extends React.Component {
 
     drawScene(viewport) {
         const star = new PIXI.Graphics();
-        star.beginFill(0xff0000);
+        star.beginFill(0xa0a0a0);
         star.drawCircle(
             450 / 2,
             200 / 2,
-            45);
+            3);
         star.endFill();
         viewport.addChild(star);
 
@@ -87,7 +85,15 @@ export default class LightcurveView extends React.Component {
             viewport,
             0, viewport.worldHeight / 2,
             viewport.worldWidth, 1,
-            0x0000ee);
+            0x2222ee);
+
+        const control = this.drawLine(
+            viewport,
+            viewport.worldWidth / 2, 0,
+            4, viewport.worldHeight,
+            0xee8888);
+        control.interactive = true;
+        control.buttonMode = true;
     }
 
     drawInfo(app) {

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -23,8 +23,8 @@ export default class LightcurveView extends React.Component {
         const viewport = new Viewport({
             screenWidth: 400,
             screenHeight: 220,
-            worldWidth: 500,
-            worldHeight: 500 * (220 / 400)
+            worldWidth: 100 * (400 / 220),
+            worldHeight: 100
         });
         this.viewport = viewport;
         this.viewport.zoom();
@@ -55,6 +55,12 @@ export default class LightcurveView extends React.Component {
             const pos = this.props.phase * this.viewport.worldWidth - 2;
             this.control.position.x = pos;
         }
+        if (prevProps.planetRadius !== this.props.planetRadius) {
+            this.viewport.removeChild(this.lightcurve);
+            this.lightcurve = this.drawLightcurve(
+                this.viewport, this.props.planetRadius);
+            this.viewport.addChild(this.lightcurve);
+        }
     }
 
     drawLine(viewport, x, y, width, height, tint = 0x000000) {
@@ -67,7 +73,7 @@ export default class LightcurveView extends React.Component {
     }
 
     drawBorder(viewport) {
-        const BORDER = 1;
+        const BORDER = 0.5;
         this.drawLine(
             viewport,
             0, 0, viewport.worldWidth, BORDER);
@@ -82,26 +88,43 @@ export default class LightcurveView extends React.Component {
             viewport.worldWidth - BORDER, 0, BORDER, viewport.worldHeight);
     }
 
+    drawLightcurve(viewport, planetRadius) {
+        const lightcurve = new PIXI.Graphics();
+        lightcurve
+            .lineStyle(0.5, 0x6666ff)
+            .moveTo(0, viewport.worldHeight / 2)
+            .lineTo(20, viewport.worldHeight / 2)
+            .quadraticCurveTo(
+                // x
+                viewport.worldWidth / 2,
+                viewport.worldHeight * Math.max(0.5, planetRadius),
+
+                // y
+                viewport.worldWidth - 20,
+                viewport.worldHeight / 2)
+            .lineTo(viewport.worldWidth, viewport.worldHeight / 2);
+        return lightcurve;
+    }
+
     drawScene(viewport) {
-        const star = new PIXI.Graphics();
-        star.beginFill(0xa0a0a0);
-        star.drawCircle(
+        const dot = new PIXI.Graphics();
+        dot.beginFill(0xa0a0a0);
+        dot.drawCircle(
             450 / 2,
             200 / 2,
             3);
-        star.endFill();
-        viewport.addChild(star);
+        dot.endFill();
+        viewport.addChild(dot);
 
-        this.drawLine(
-            viewport,
-            0, viewport.worldHeight / 2,
-            viewport.worldWidth, 1,
-            0x6666ff);
+        const lightcurve = this.drawLightcurve(
+            viewport, this.props.planetRadius);
+        this.lightcurve = lightcurve;
+        viewport.addChild(lightcurve);
 
         const control = this.drawLine(
             viewport,
             viewport.worldWidth / 2 - 2, 0,
-            4, viewport.worldHeight,
+            2, viewport.worldHeight,
             0xee8888);
         control.interactive = true;
         control.buttonMode = true;
@@ -110,9 +133,9 @@ export default class LightcurveView extends React.Component {
 
     drawInfo(app) {
         const line = new PIXI.Graphics()
-        line.lineStyle(2, 0x000000);
-        line.moveTo(70, 240);
-        line.lineTo(430, 240);
+                             .lineStyle(2, 0x000000)
+                             .moveTo(70, 240)
+                             .lineTo(430, 240);
         app.stage.addChild(line);
 
         const leftText = new PIXI.Text('Normalized Flux', {

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -18,6 +18,8 @@ export default class LightcurveView extends React.Component {
         return <div ref={(el) => {this.el = el}}></div>;
     }
     componentDidMount() {
+        // The viewport contains the plotted, dynamic and scalable
+        // scene.
         const viewport = new Viewport({
             screenWidth: 400,
             screenHeight: 220,
@@ -27,6 +29,8 @@ export default class LightcurveView extends React.Component {
         this.viewport = viewport;
         this.viewport.zoom();
 
+        // The app contains the textual info with the viewport plot
+        // in the center.
         const app = new PIXI.Application({
             backgroundColor: 0xffffff,
             width: 480,
@@ -44,6 +48,13 @@ export default class LightcurveView extends React.Component {
         this.drawBorder(viewport);
         this.drawScene(viewport);
         this.drawInfo(this.app);
+    }
+    componentDidUpdate(prevProps) {
+        if (prevProps.phase !== this.props.phase) {
+            // Scale the phase to the viewport's worldWidth.
+            const pos = this.props.phase * this.viewport.worldWidth - 2;
+            this.control.position.x = pos;
+        }
     }
 
     drawLine(viewport, x, y, width, height, tint = 0x000000) {
@@ -89,11 +100,12 @@ export default class LightcurveView extends React.Component {
 
         const control = this.drawLine(
             viewport,
-            viewport.worldWidth / 2, 0,
+            viewport.worldWidth / 2 - 2, 0,
             4, viewport.worldHeight,
             0xee8888);
         control.interactive = true;
         control.buttonMode = true;
+        this.control = control;
     }
 
     drawInfo(app) {
@@ -119,5 +131,16 @@ export default class LightcurveView extends React.Component {
 }
 
 LightcurveView.propTypes = {
+    showTheoreticalCurve: PropTypes.bool.isRequired,
+    showSimulatedMeasurements: PropTypes.bool.isRequired,
+    noise: PropTypes.number.isRequired,
+    number: PropTypes.number.isRequired,
+    planetMass: PropTypes.number.isRequired,
+    planetRadius: PropTypes.number.isRequired,
+    planetSemimajorAxis: PropTypes.number.isRequired,
+    planetEccentricity: PropTypes.number.isRequired,
+    starMass: PropTypes.number.isRequired,
+    inclination: PropTypes.number.isRequired,
+    longitude: PropTypes.number.isRequired,
     phase: PropTypes.number.isRequired
 };

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -126,6 +126,16 @@ export default class LightcurveView extends React.Component {
         leftText.position.x = 14;
         leftText.position.y = 160;
         app.stage.addChild(leftText);
+
+        const bottomText = new PIXI.Text('Eclipse takes 2.93 hours of 3.56 day orbit', {
+            fontFamily: 'Arial',
+            fontSize: 13,
+            fill: 0x000000,
+            align: 'center'
+        });
+        bottomText.position.x = 130;
+        bottomText.position.y = 252;
+        app.stage.addChild(bottomText);
     }
 
     onDragStart(e) {

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import * as PIXI from 'pixi.js';
+import Viewport from 'pixi-viewport';
 
 export default class LightcurveView extends React.Component {
     constructor(props) {
@@ -17,9 +18,21 @@ export default class LightcurveView extends React.Component {
         return <div ref={(el) => {this.el = el}}></div>;
     }
     componentDidMount() {
+        const viewport = new Viewport({
+            screenWidth: 400,
+            screenHeight: 220,
+            worldWidth: 500,
+            worldHeight: 500 * (220 / 400)
+        });
+        this.viewport = viewport;
+        this.viewport
+            .drag()
+            .wheel()
+            .zoom();
+
         const app = new PIXI.Application({
             backgroundColor: 0xffffff,
-            width: 450,
+            width: 480,
             height: 300,
             sharedLoader: true,
             sharedTicker: true,
@@ -27,6 +40,62 @@ export default class LightcurveView extends React.Component {
         });
         this.app = app;
         this.el.appendChild(app.view);
+
+        this.app.stage.addChild(viewport);
+        viewport.position.x = 50;
+
+        this.drawBorder(viewport);
+        this.drawScene(viewport);
+        this.drawInfo(this.app);
+    }
+
+    drawLine(viewport, x, y, width, height, tint = 0x000000) {
+        const line = viewport.addChild(new PIXI.Sprite(PIXI.Texture.WHITE));
+        line.tint = tint;
+        line.position.set(x, y);
+        line.width = width;
+        line.height = height;
+    }
+
+    drawBorder(viewport) {
+        const BORDER = 1;
+        this.drawLine(
+            viewport,
+            0, 0, viewport.worldWidth, BORDER);
+        this.drawLine(
+            viewport,
+            0, viewport.worldHeight - BORDER, viewport.worldWidth, BORDER);
+        this.drawLine(
+            viewport,
+            0, 0, BORDER, viewport.worldHeight);
+        this.drawLine(
+            viewport,
+            viewport.worldWidth - BORDER, 0, BORDER, viewport.worldHeight);
+    }
+
+    drawScene(viewport) {
+        const star = new PIXI.Graphics();
+        star.beginFill(0xff0000);
+        star.drawCircle(
+            450 / 2,
+            200 / 2,
+            45);
+        star.endFill();
+        viewport.addChild(star);
+
+        this.drawLine(
+            viewport,
+            0, viewport.worldHeight / 2,
+            viewport.worldWidth, 1,
+            0x0000ee);
+    }
+
+    drawInfo(app) {
+        const line = new PIXI.Graphics()
+        line.lineStyle(2, 0x000000);
+        line.moveTo(70, 240);
+        line.lineTo(430, 240);
+        app.stage.addChild(line);
     }
 
     onDragStart(e) {

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -96,7 +96,7 @@ export default class LightcurveView extends React.Component {
             viewport,
             0, viewport.worldHeight / 2,
             viewport.worldWidth, 1,
-            0x2222ee);
+            0x6666ff);
 
         const control = this.drawLine(
             viewport,
@@ -114,6 +114,18 @@ export default class LightcurveView extends React.Component {
         line.moveTo(70, 240);
         line.lineTo(430, 240);
         app.stage.addChild(line);
+
+        const leftText = new PIXI.Text('Normalized Flux', {
+            fontFamily: 'Arial',
+            fontSize: 14,
+            fontWeight: 'bold',
+            fill: 0x000000,
+            align: 'center'
+        });
+        leftText.rotation = -Math.PI / 2;
+        leftText.position.x = 14;
+        leftText.position.y = 160;
+        app.stage.addChild(leftText);
     }
 
     onDragStart(e) {

--- a/exoplanet-transit-simulator/src/LightcurveView.jsx
+++ b/exoplanet-transit-simulator/src/LightcurveView.jsx
@@ -47,7 +47,7 @@ export default class LightcurveView extends React.Component {
 
         this.drawBorder(viewport);
         this.drawScene(viewport);
-        this.drawInfo(this.app);
+        this.drawInfo(this.app, viewport);
     }
     componentDidUpdate(prevProps) {
         if (prevProps.phase !== this.props.phase) {
@@ -131,7 +131,7 @@ export default class LightcurveView extends React.Component {
         this.control = control;
     }
 
-    drawInfo(app) {
+    drawInfo(app, viewport) {
         const line = new PIXI.Graphics()
                              .lineStyle(2, 0x000000)
                              .moveTo(70, 240)
@@ -159,6 +159,31 @@ export default class LightcurveView extends React.Component {
         bottomText.position.x = 130;
         bottomText.position.y = 252;
         app.stage.addChild(bottomText);
+
+        this.drawYAxisLabels(app, viewport)
+    }
+
+    /**
+     * Draw dynamic axis labels in the app container, with respect to
+     * the viewport's world co-ordinates.
+     */
+    drawYAxisLabels(app, viewport) {
+        viewport.fitYHeight = function(height, center) {
+            let save;
+            if (center) {
+                save = this.center;
+            }
+            height = height || this.worldHeight;
+            this.scale.y = this.screenHeight / height;
+            //this.scale.x = this.scale.y
+            if (center) {
+                this.moveCenter(save);
+            }
+            return this;
+        };
+        viewport.fitYHeight.bind(viewport);
+
+        //viewport.fitYHeight(200);
     }
 
     onDragStart(e) {

--- a/exoplanet-transit-simulator/src/RangeStepInput.jsx
+++ b/exoplanet-transit-simulator/src/RangeStepInput.jsx
@@ -31,6 +31,7 @@ export default class RangeStepInput extends React.Component {
                    value={this.props.value}
                    name={this.props.name}
                    id={this.props.id}
+                   disabled={this.props.disabled}
                    onChange={this.props.onChange}
                    onMouseDown={this.onMouseDown}
                    onMouseUp={this.onMouseUp}
@@ -77,5 +78,6 @@ RangeStepInput.propTypes = {
     min: PropTypes.number,
     max: PropTypes.number,
     id: PropTypes.string,
-    name: PropTypes.string
+    name: PropTypes.string,
+    disabled: PropTypes.bool
 };

--- a/exoplanet-transit-simulator/src/TransitView.jsx
+++ b/exoplanet-transit-simulator/src/TransitView.jsx
@@ -29,6 +29,13 @@ export default class TransitView extends React.Component {
         this.el.appendChild(app.view);
         this.drawScene(app);
     }
+    componentDidUpdate(prevProps) {
+        if (prevProps.phase !== this.props.phase) {
+            // phase * starRadius * 2
+            const pos = this.props.phase * 140;
+            this.planet.position.x = pos;
+        }
+    }
     drawScene(app) {
         const starRadius = 70;
         const star = new PIXI.Graphics();
@@ -56,10 +63,12 @@ export default class TransitView extends React.Component {
         planet.buttonMode = true;
         planet.beginFill(0xa0a0a0);
         planet.drawCircle(
-            app.view.width / 2,
+            (app.view.width / 2) - starRadius,
             (app.view.height / 2) + 25,
             planetRadius);
         planet.endFill();
+        planet.position.x = this.props.phase * starRadius * 2;
+        this.planet = planet;
         app.stage.addChild(planet);
     }
     onDragStart(e) {

--- a/exoplanet-transit-simulator/src/TransitView.jsx
+++ b/exoplanet-transit-simulator/src/TransitView.jsx
@@ -52,6 +52,8 @@ export default class TransitView extends React.Component {
 
         const planetRadius = 10;
         const planet = new PIXI.Graphics();
+        planet.interactive = true;
+        planet.buttonMode = true;
         planet.beginFill(0xa0a0a0);
         planet.drawCircle(
             app.view.width / 2,

--- a/exoplanet-transit-simulator/src/main.jsx
+++ b/exoplanet-transit-simulator/src/main.jsx
@@ -3,13 +3,36 @@ import ReactDOM from 'react-dom';
 import LightcurveView from './LightcurveView';
 import TransitView from './TransitView';
 import RangeStepInput from './RangeStepInput';
+import {forceNumber} from './utils';
 
 class ExoplanetTransitSimulator extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
+            preset: 0,
+
+            // Lightcurve view settings
+            showTheoreticalCurve: true,
+            showSimulatedMeasurements: false,
+            noise: 0.1,
+            number: 50,
+
+            // Planet properties
+            planetMass: 0.657,
+            planetRadius: 1.32,
+            planetSemimajorAxis: 0.047,
+            planetEccentricity: 0,
+
+            // Star properties
+            starMass: 1.09,
+
+            // System orientation and phase
+            inclination: 86.929,
+            longitude: 0,
             phase: 0
         }
+
+        this.handleInputChange = this.handleInputChange.bind(this);
     }
     render() {
         return <React.Fragment>
@@ -80,9 +103,16 @@ class ExoplanetTransitSimulator extends React.Component {
                                         <input
                                             type="number" name="planetAxis"
                                             className="form-control form-control-sm"
+                                            disabled={!this.state.showSimulatedMeasurements}
+                                            value={this.state.noise}
+                                            onChange={this.handleInputChange}
                                             step={0.01} />
-                                        <RangeStepInput className="form-control"
-                                               min={0.01} max={10} step={0.01} />
+                                        <RangeStepInput
+                                            className="form-control"
+                                            disabled={!this.state.showSimulatedMeasurements}
+                                            value={this.state.noise}
+                                            onChange={this.handleInputChange}
+                                            min={0.01} max={10} step={0.01} />
                                     </div>
                                 </div>
                                 <div className="form-group row">
@@ -93,9 +123,16 @@ class ExoplanetTransitSimulator extends React.Component {
                                         <input
                                             type="number" name="planetAxis"
                                             className="form-control form-control-sm"
+                                            disabled={!this.state.showSimulatedMeasurements}
+                                            value={this.state.number}
+                                            onChange={this.handleInputChange}
                                             step={0.01} />
-                                        <RangeStepInput className="form-control"
-                                               min={0.01} max={10} step={0.01} />
+                                        <RangeStepInput
+                                            className="form-control"
+                                            disabled={!this.state.showSimulatedMeasurements}
+                                            value={this.state.number}
+                                            onChange={this.handleInputChange}
+                                            min={0.01} max={10} step={0.01} />
                                     </div>
                                 </div>
                             </div>
@@ -119,11 +156,17 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetMass"
                                     className="form-control form-control-sm"
-                                    step={0.01} />
+                                    value={this.state.planetMass}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2}
+                                    step={0.0001} />
                                 M<sub>jup</sub>
 
-                                <RangeStepInput className="form-control"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    value={this.state.planetMass}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2} step={0.0001} />
                             </div>
                         </div>
                         <div className="form-group row">
@@ -134,11 +177,17 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetRadius"
                                     className="form-control form-control-sm"
-                                    step={0.01} />
+                                    value={this.state.planetRadius}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2}
+                                    step={0.0001} />
                                 R<sub>jup</sub>
 
-                                <RangeStepInput className="form-control"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    value={this.state.planetRadius}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2} step={0.0001} />
                             </div>
                         </div>
                         <div className="form-group row">
@@ -149,11 +198,18 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetAxis"
                                     className="form-control form-control-sm"
-                                    step={0.01} />
+                                    value={this.state.planetSemimajorAxis}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2}
+                                    step={0.0001} />
                                 AU
 
-                                <RangeStepInput className="form-control"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    value={this.state.planetSemimajorAxis}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={2}
+                                    step={0.0001} />
                             </div>
                         </div>
                         <div className="form-group row">
@@ -164,10 +220,17 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetEccentricity"
                                     className="form-control form-control-sm"
+                                    value={this.state.planetEccentricity}
+                                    onChange={this.handleInputChange}
+                                    min={0} max={0.4}
                                     step={0.01} />
 
-                                <RangeStepInput className="form-control"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    value={this.state.planetEccentricity}
+                                    onChange={this.handleInputChange}
+                                    min={0} max={0.4}
+                                    step={0.01} />
                             </div>
                         </div>
                     </div>
@@ -185,11 +248,16 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input type="number"
                                        name="starMass"
                                        className="form-control form-control-sm"
+                                       value={this.state.starMass}
+                                       onChange={this.handleInputChange}
                                        step={0.01} />
                                 M<sub>sun</sub>
 
-                                <RangeStepInput className="form-control"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    value={this.state.starMass}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={10} step={0.01} />
                             </div>
                         </div>
                     </div>
@@ -210,12 +278,18 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
 
                             <div className="col-sm-10">
-                                <input type="number" name="planetAxis"
-                                       className="form-control form-control-sm"
-                                       step={0.01} />&deg;
+                                <input
+                                    type="number" name="planetAxis"
+                                    className="form-control form-control-sm"
+                                    value={this.state.inclination}
+                                    onChange={this.handleInputChange}
+                                    step={0.01} />&deg;
 
-        <RangeStepInput className="form-control"
-               min={0.01} max={10} step={0.01} />
+        <RangeStepInput
+            className="form-control"
+            value={this.state.inclination}
+            onChange={this.handleInputChange}
+            min={0.01} max={10} step={0.01} />
                             </div>
                         </div>
 
@@ -228,10 +302,15 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetAxis"
                                     className="form-control form-control-sm"
+                                    value={this.state.longitude}
+                                    onChange={this.handleInputChange}
                                     step={0.01} />&deg;
 
-        <RangeStepInput className="form-control"
-               min={0.01} max={10} step={0.01} />
+        <RangeStepInput
+            className="form-control"
+            value={this.state.longitude}
+            onChange={this.handleInputChange}
+            min={0.01} max={10} step={0.01} />
                             </div>
                         </div>
 
@@ -242,15 +321,34 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
 
                             <div className="col-sm-10">
-                                <RangeStepInput className="form-control"
-                                       name="phase" id="phaseSlider"
-                                       min={0.01} max={10} step={0.01} />
+                                <RangeStepInput
+                                    className="form-control"
+                                    name="phase" id="phaseSlider"
+                                    value={this.state.phase}
+                                    onChange={this.handleInputChange}
+                                    min={0.01} max={10} step={0.01} />
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
         </React.Fragment>;
+    }
+    handleInputChange(event) {
+        const target = event.target;
+        const name = target.name;
+        let value = target.type === 'checkbox' ?
+                    target.checked : target.value;
+
+        if (target.type === 'radio') {
+            value = target.id === (target.name + 'Radio');
+        } else if (target.type === 'range') {
+            value = forceNumber(value);
+        }
+
+        this.setState({
+            [name]: value
+        });
     }
 }
 

--- a/exoplanet-transit-simulator/src/main.jsx
+++ b/exoplanet-transit-simulator/src/main.jsx
@@ -176,7 +176,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     value={this.state.planetMass}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
-                                    step={0.0001} />
+                                    step={0.001} />
                                 M<sub>jup</sub>
 
                                 <RangeStepInput
@@ -184,7 +184,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     name="planetMass"
                                     value={this.state.planetMass}
                                     onChange={this.handleInputChange}
-                                    min={0.01} max={2} step={0.0001} />
+                                    min={0.01} max={2} step={0.001} />
                             </div>
                         </div>
                         <div className="form-group row">
@@ -199,7 +199,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     value={this.state.planetRadius}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
-                                    step={0.0001} />
+                                    step={0.001} />
                                 R<sub>jup</sub>
 
                                 <RangeStepInput
@@ -207,7 +207,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     name="planetRadius"
                                     value={this.state.planetRadius}
                                     onChange={this.handleInputChange}
-                                    min={0.01} max={2} step={0.0001} />
+                                    min={0.01} max={2} step={0.001} />
                             </div>
                         </div>
                         <div className="form-group row">
@@ -222,7 +222,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     value={this.state.planetSemimajorAxis}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
-                                    step={0.0001} />
+                                    step={0.001} />
                                 AU
 
                                 <RangeStepInput
@@ -231,7 +231,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     value={this.state.planetSemimajorAxis}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
-                                    step={0.0001} />
+                                    step={0.001} />
                             </div>
                         </div>
                         <div className="form-group row">

--- a/exoplanet-transit-simulator/src/main.jsx
+++ b/exoplanet-transit-simulator/src/main.jsx
@@ -104,12 +104,14 @@ class ExoplanetTransitSimulator extends React.Component {
                                             type="number" name="planetAxis"
                                             className="form-control form-control-sm"
                                             disabled={!this.state.showSimulatedMeasurements}
+                                            name="noise"
                                             value={this.state.noise}
                                             onChange={this.handleInputChange}
                                             step={0.01} />
                                         <RangeStepInput
                                             className="form-control"
                                             disabled={!this.state.showSimulatedMeasurements}
+                                            name="noise"
                                             value={this.state.noise}
                                             onChange={this.handleInputChange}
                                             min={0.01} max={10} step={0.01} />
@@ -124,12 +126,14 @@ class ExoplanetTransitSimulator extends React.Component {
                                             type="number" name="planetAxis"
                                             className="form-control form-control-sm"
                                             disabled={!this.state.showSimulatedMeasurements}
+                                            name="number"
                                             value={this.state.number}
                                             onChange={this.handleInputChange}
                                             step={0.01} />
                                         <RangeStepInput
                                             className="form-control"
                                             disabled={!this.state.showSimulatedMeasurements}
+                                            name="number"
                                             value={this.state.number}
                                             onChange={this.handleInputChange}
                                             min={0.01} max={10} step={0.01} />
@@ -156,6 +160,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetMass"
                                     className="form-control form-control-sm"
+                                    name="planetMass"
                                     value={this.state.planetMass}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
@@ -164,6 +169,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                                 <RangeStepInput
                                     className="form-control"
+                                    name="planetMass"
                                     value={this.state.planetMass}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2} step={0.0001} />
@@ -177,6 +183,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetRadius"
                                     className="form-control form-control-sm"
+                                    name="planetRadius"
                                     value={this.state.planetRadius}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
@@ -185,6 +192,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                                 <RangeStepInput
                                     className="form-control"
+                                    name="planetRadius"
                                     value={this.state.planetRadius}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2} step={0.0001} />
@@ -198,6 +206,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetAxis"
                                     className="form-control form-control-sm"
+                                    name="planetSemimajorAxis"
                                     value={this.state.planetSemimajorAxis}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
@@ -206,6 +215,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                                 <RangeStepInput
                                     className="form-control"
+                                    name="planetSemimajorAxis"
                                     value={this.state.planetSemimajorAxis}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={2}
@@ -220,6 +230,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetEccentricity"
                                     className="form-control form-control-sm"
+                                    name="planetEccentricity"
                                     value={this.state.planetEccentricity}
                                     onChange={this.handleInputChange}
                                     min={0} max={0.4}
@@ -227,6 +238,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                                 <RangeStepInput
                                     className="form-control"
+                                    name="planetEccentricity"
                                     value={this.state.planetEccentricity}
                                     onChange={this.handleInputChange}
                                     min={0} max={0.4}
@@ -248,6 +260,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input type="number"
                                        name="starMass"
                                        className="form-control form-control-sm"
+                                       name="starMass"
                                        value={this.state.starMass}
                                        onChange={this.handleInputChange}
                                        step={0.01} />
@@ -255,6 +268,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                                 <RangeStepInput
                                     className="form-control"
+                                    name="starMass"
                                     value={this.state.starMass}
                                     onChange={this.handleInputChange}
                                     min={0.01} max={10} step={0.01} />
@@ -281,12 +295,14 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetAxis"
                                     className="form-control form-control-sm"
+                                    name="inclination"
                                     value={this.state.inclination}
                                     onChange={this.handleInputChange}
                                     step={0.01} />&deg;
 
         <RangeStepInput
             className="form-control"
+            name="inclination"
             value={this.state.inclination}
             onChange={this.handleInputChange}
             min={0.01} max={10} step={0.01} />
@@ -302,12 +318,14 @@ class ExoplanetTransitSimulator extends React.Component {
                                 <input
                                     type="number" name="planetAxis"
                                     className="form-control form-control-sm"
+                                    name="longitude"
                                     value={this.state.longitude}
                                     onChange={this.handleInputChange}
                                     step={0.01} />&deg;
 
         <RangeStepInput
             className="form-control"
+            name="longitude"
             value={this.state.longitude}
             onChange={this.handleInputChange}
             min={0.01} max={10} step={0.01} />
@@ -342,7 +360,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
         if (target.type === 'radio') {
             value = target.id === (target.name + 'Radio');
-        } else if (target.type === 'range') {
+        } else if (target.type === 'range' || target.type === 'number') {
             value = forceNumber(value);
         }
 

--- a/exoplanet-transit-simulator/src/main.jsx
+++ b/exoplanet-transit-simulator/src/main.jsx
@@ -29,7 +29,7 @@ class ExoplanetTransitSimulator extends React.Component {
             // System orientation and phase
             inclination: 86.929,
             longitude: 0,
-            phase: 0
+            phase: 0.5
         }
 
         this.handleInputChange = this.handleInputChange.bind(this);
@@ -74,7 +74,19 @@ class ExoplanetTransitSimulator extends React.Component {
                 </div>
 
                 <div className="col-6">
-                    <LightcurveView phase={this.state.phase} />
+                    <LightcurveView
+                        showTheoreticalCurve={this.state.showTheoreticalCurve}
+                        showSimulatedMeasurements={this.state.showSimulatedMeasurements}
+                        noise={this.state.noise}
+                        number={this.state.number}
+                        planetMass={this.state.planetMass}
+                        planetRadius={this.state.planetRadius}
+                        planetSemimajorAxis={this.state.planetSemimajorAxis}
+                        planetEccentricity={this.state.planetEccentricity}
+                        starMass={this.state.starMass}
+                        inclination={this.state.inclination}
+                        longitude={this.state.longitude}
+                        phase={this.state.phase} />
                     <div className="row">
                         <div className="col">
                             <div className="form-inline">
@@ -101,7 +113,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     </label>
                                     <div className="col-sm-10">
                                         <input
-                                            type="number" name="planetAxis"
+                                            type="number"
                                             className="form-control form-control-sm"
                                             disabled={!this.state.showSimulatedMeasurements}
                                             name="noise"
@@ -123,7 +135,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     </label>
                                     <div className="col-sm-10">
                                         <input
-                                            type="number" name="planetAxis"
+                                            type="number"
                                             className="form-control form-control-sm"
                                             disabled={!this.state.showSimulatedMeasurements}
                                             name="number"
@@ -158,7 +170,7 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetMass"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="planetMass"
                                     value={this.state.planetMass}
@@ -181,7 +193,7 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetRadius"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="planetRadius"
                                     value={this.state.planetRadius}
@@ -204,7 +216,7 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetAxis"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="planetSemimajorAxis"
                                     value={this.state.planetSemimajorAxis}
@@ -228,7 +240,7 @@ class ExoplanetTransitSimulator extends React.Component {
                             </label>
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetEccentricity"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="planetEccentricity"
                                     value={this.state.planetEccentricity}
@@ -258,7 +270,6 @@ class ExoplanetTransitSimulator extends React.Component {
 
                             <div className="col-sm-10">
                                 <input type="number"
-                                       name="starMass"
                                        className="form-control form-control-sm"
                                        name="starMass"
                                        value={this.state.starMass}
@@ -293,7 +304,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetAxis"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="inclination"
                                     value={this.state.inclination}
@@ -316,7 +327,7 @@ class ExoplanetTransitSimulator extends React.Component {
 
                             <div className="col-sm-10">
                                 <input
-                                    type="number" name="planetAxis"
+                                    type="number"
                                     className="form-control form-control-sm"
                                     name="longitude"
                                     value={this.state.longitude}
@@ -344,7 +355,7 @@ class ExoplanetTransitSimulator extends React.Component {
                                     name="phase" id="phaseSlider"
                                     value={this.state.phase}
                                     onChange={this.handleInputChange}
-                                    min={0.01} max={10} step={0.01} />
+                                    min={0} max={1} step={0.01} />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
This adds a pixi scene for the LightcurveView including [pixi-viewport](https://github.com/davidfig/pixi-viewport) which will let me treat the plot as its own scene with its own world co-ordinates.

I'm hoping that making the configurable curve + scaling the Y-axis zoom factor will be straightforward from here, but we'll see.