### PR TITLE
Refactor mouse event handlers

### DIFF
--- a/sun-motion-simulator/package-lock.json
+++ b/sun-motion-simulator/package-lock.json
@@ -4324,7 +4324,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4342,11 +4343,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4359,15 +4362,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4470,7 +4476,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4480,6 +4487,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4492,17 +4500,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4519,6 +4530,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4591,7 +4603,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4601,6 +4614,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4676,7 +4690,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4706,6 +4721,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4723,6 +4739,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4761,11 +4778,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -10104,11 +10123,6 @@
       "version": "0.96.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.96.0.tgz",
       "integrity": "sha512-tS+A5kelQgBblElc/E1G5zR3m6wNjbqmrf6OAjijuNJM7yoYQjOktPoa+Lglx73OTiTOJ3+Ff+pgWdOFt7cOhQ=="
-    },
-    "threex-domevents": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/threex-domevents/-/threex-domevents-1.0.0.tgz",
-      "integrity": "sha1-3vOBHkOMFP+uIFAzpO22SFDx2kU="
     },
     "throat": {
       "version": "4.1.0",

--- a/sun-motion-simulator/package.json
+++ b/sun-motion-simulator/package.json
@@ -29,8 +29,7 @@
     "pixi.js": "^4.8.1",
     "react": "~16.5.0",
     "react-dom": "~16.5.0",
-    "three": "^0.96.0",
-    "threex-domevents": "^1.0.0"
+    "three": "^0.96.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/sun-motion-simulator/webpack.config.js
+++ b/sun-motion-simulator/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     resolve: {
         extensions: ['*', '.js', '.jsx'],
         alias: {
+            'three/Detector': path.join(__dirname, 'node_modules/three/examples/js/Detector.js'),
             'three/OrbitControls': path.join(__dirname, 'node_modules/three/examples/js/controls/OrbitControls.js'),
             'three/DragControls': path.join(__dirname, 'node_modules/three/examples/js/controls/DragControls.js'),
             'three/CopyShader': path.join(__dirname, 'node_modules/three/examples/js/shaders/CopyShader.js'),


### PR DESCRIPTION
This fixes a bug where objects behind the green plane would get selected on mouseover.

This removes threex.domevents, which isn't necessary.

Three.js's [Raycaster](https://threejs.org/docs/index.html#api/en/core/Raycaster) class is sufficient to pick out mouseover objects.

This is kind of based on the example here:
https://threejs.org/examples/?q=ray#webgl_raycast_sprite