### PR TITLE
Prevent text selection in simulation areas

### DIFF
--- a/exoplanet-transit-simulator/index.html
+++ b/exoplanet-transit-simulator/index.html
@@ -6,6 +6,15 @@
  
         <link rel="stylesheet" href="../css/bootstrap.min.css">
         <style type="text/css">
+        #sim-container {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -khtml-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
         input[type="number"] {
             width: 70px !important;
         }

--- a/lunar-phase-simulator/index.html
+++ b/lunar-phase-simulator/index.html
@@ -6,6 +6,15 @@
  
         <link rel="stylesheet" href="../css/bootstrap.min.css">
         <style type="text/css">
+        #sim-container {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -khtml-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
         #HorizonView>canvas {
             width: 228px;
             height: 228px;

--- a/small-angle-demo/index.html
+++ b/small-angle-demo/index.html
@@ -4,8 +4,17 @@
         <meta charset="UTF-8" />
         <title>Small-Angle Approximation Demonstrator</title>
  
-        <link rel="stylesheet" href="../css/bootstrap.min.css">        
+        <link rel="stylesheet" href="../css/bootstrap.min.css">
         <style type="text/css">
+        #sim-container {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -khtml-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
         input[type="number"] {
             width: 80px !important;
         }

--- a/sun-motion-simulator/index.html
+++ b/sun-motion-simulator/index.html
@@ -6,6 +6,15 @@
  
         <link rel="stylesheet" href="../css/bootstrap.min.css">
         <style type="text/css">
+        #sim-container {
+            -webkit-touch-callout: none;
+            -webkit-user-select: none;
+            -khtml-user-select: none;
+            -moz-user-select: none;
+            -ms-user-select: none;
+            user-select: none;
+        }
+
         #HorizonView,
         #HorizonView>canvas {
             width: 430px;


### PR DESCRIPTION
Clicking around the simulation often causes the text to be selected,
which isn't the behavior we want.