### PR TITLE
Ecliptic: add general year motion  #111, #110

### DIFF
--- a/sun-motion-simulator/src/main.jsx
+++ b/sun-motion-simulator/src/main.jsx
@@ -88,6 +88,7 @@ class SunMotionSim extends React.Component {
             <div className="row mt-2">
                 <div className="col">
                     <HorizonView
+                        dateTime={this.state.dateTime}
                         latitude={this.state.latitude}
                         showDeclinationCircle={this.state.showDeclinationCircle}
                         showEcliptic={this.state.showEcliptic}


### PR DESCRIPTION
The ecliptic and prime hour circle needs to rotate throughout the year
with the sun declination, as well as the its daily rotation. I've added
the general idea here which can be seen by dragging the calendar date
throughout the year, but it's not perfect yet.