### PR TITLE
Fix moon positioning bugs

### DIFF
--- a/lunar-phase-simulator/src/MainView.jsx
+++ b/lunar-phase-simulator/src/MainView.jsx
@@ -118,7 +118,7 @@ export default class MainView extends React.Component {
         cancelAnimationFrame(this.frameId)
     }
     animate() {
-        this.moonContainer.position = this.getMoonPos(this.props.moonPhase);
+        this.moonContainer.position = this.getMoonPos(this.props.moonAngle);
 
         // Rotate the moon about the earth, but not the shade from the
         // sun.
@@ -126,7 +126,7 @@ export default class MainView extends React.Component {
         this.moonContainer.children.filter(el => {
             return el.name === 'moonObj' || el.name === 'landmark';
         }).forEach(el => {
-            el.rotation = -me.props.moonPhase;
+            el.rotation = -me.props.moonAngle;
         });
 
         if (this.state.isHoveringOnMoon || this.draggingMoon) {
@@ -171,7 +171,7 @@ export default class MainView extends React.Component {
         return timeCompass;
     }
     drawMoon(moonResource, highlightResource) {
-        const pos = this.getMoonPos(this.props.moonPhase);
+        const pos = this.getMoonPos(this.props.moonAngle);
 
         const moonContainer = new PIXI.Container();
         moonContainer.name = 'moon';
@@ -381,7 +381,7 @@ export default class MainView extends React.Component {
 
 MainView.propTypes = {
     observerAngle: PropTypes.number.isRequired,
-    moonPhase: PropTypes.number.isRequired,
+    moonAngle: PropTypes.number.isRequired,
     onObserverAngleUpdate: PropTypes.func.isRequired,
     onMoonPosUpdate: PropTypes.func.isRequired,
     showAngle: PropTypes.bool.isRequired,

--- a/lunar-phase-simulator/src/MoonPhaseView.jsx
+++ b/lunar-phase-simulator/src/MoonPhaseView.jsx
@@ -20,15 +20,15 @@ export default class MoonPhaseView extends React.Component {
         this.center = new PIXI.Point(228 / 2, 215 / 2);
     }
     render() {
-        const phaseSlot = getPhaseSlot(this.props.moonPhase);
+        const phaseSlot = getPhaseSlot(this.props.moonAngle);
         const timeSinceNewMoon = Math.round(
-            getTimeSinceNewMoon(this.props.moonPhase));
+            getTimeSinceNewMoon(this.props.moonAngle));
         return <div>
             <div style={{
                 visibility: this.state.isHidden ? 'hidden' : 'visible'
             }}>
                 <select className="form-control form-control-sm"
-                        onChange={this.onMoonPhaseUpdate.bind(this)}
+                        onChange={this.onMoonAngleUpdate.bind(this)}
                         value={phaseSlot}>
                     <option value={180}>New Moon</option>
                     <option value={-135}>Waxing Crescent</option>
@@ -44,7 +44,7 @@ export default class MoonPhaseView extends React.Component {
                 <div className="text-center">
                     {
                         roundToOnePlace(getPercentIlluminated(
-                            this.props.moonPhase - Math.PI))
+                            this.props.moonAngle - Math.PI))
                     }% illuminated
                 </div>
                 <div className="text-center">Time since new moon:</div>
@@ -79,9 +79,9 @@ export default class MoonPhaseView extends React.Component {
         });
     }
     componentDidUpdate(prevProps) {
-        if (prevProps.moonPhase !== this.props.moonPhase) {
+        if (prevProps.moonAngle !== this.props.moonAngle) {
             this.drawPhase(this.leftShade, this.rightShade,
-                           this.convertPhase(this.props.moonPhase));
+                           this.convertPhase(this.props.moonAngle));
         }
         if (prevProps.showLunarLandmark !== this.props.showLunarLandmark) {
             this.lunarLandmark.visible = this.props.showLunarLandmark;
@@ -91,7 +91,7 @@ export default class MoonPhaseView extends React.Component {
         this.drawMoon(this.app);
         this.drawShades(this.app);
         this.drawPhase(this.leftShade, this.rightShade,
-                       this.convertPhase(this.props.moonPhase));
+                       this.convertPhase(this.props.moonAngle));
         this.drawLunarLandmark(this.app);
     }
     drawMoon(app) {
@@ -191,8 +191,8 @@ export default class MoonPhaseView extends React.Component {
         app.stage.addChild(g);
         this.lunarLandmark = g;
     }
-    onMoonPhaseUpdate(e) {
-        this.props.onMoonPhaseUpdate(
+    onMoonAngleUpdate(e) {
+        this.props.onMoonAngleUpdate(
             degToRad(forceNumber(e.target.value))
         );
     }
@@ -202,7 +202,7 @@ export default class MoonPhaseView extends React.Component {
 }
 
 MoonPhaseView.propTypes = {
-    moonPhase: PropTypes.number.isRequired,
-    onMoonPhaseUpdate: PropTypes.func.isRequired,
+    moonAngle: PropTypes.number.isRequired,
+    onMoonAngleUpdate: PropTypes.func.isRequired,
     showLunarLandmark: PropTypes.bool.isRequired
 };

--- a/lunar-phase-simulator/src/main.jsx
+++ b/lunar-phase-simulator/src/main.jsx
@@ -16,10 +16,8 @@ class LunarPhaseSim extends React.Component {
              * the sky.
              */
             observerAngle: Math.PI / 2,
-            moonPhase: -Math.PI,
-            // moonObserverPos is a function of observerAngle and
-            // moonPhase.
-            moonObserverPos: Math.PI / 2,
+            moonAngle: -Math.PI,
+
             isPlaying: false,
             animationRate: 1,
             showAngle: false,
@@ -57,7 +55,7 @@ class LunarPhaseSim extends React.Component {
                 <div className="col-lg-8">
                     <MainView
                         observerAngle={this.state.observerAngle}
-                        moonPhase={this.state.moonPhase}
+                        moonAngle={this.state.moonAngle}
                         showAngle={this.state.showAngle}
                         showLunarLandmark={this.state.showLunarLandmark}
                         showTimeTickmarks={this.state.showTimeTickmarks}
@@ -178,14 +176,14 @@ class LunarPhaseSim extends React.Component {
                         <h4>Moon Phase</h4>
                         <MoonPhaseView
                             showLunarLandmark={this.state.showLunarLandmark}
-                            moonPhase={this.state.moonPhase}
-                            onMoonPhaseUpdate={this.onMoonPhaseUpdate.bind(this)} />
+                            moonAngle={this.state.moonAngle}
+                            onMoonAngleUpdate={this.onMoonAngleUpdate.bind(this)} />
                     </div>
                     <div>
                         <h4>Horizon Diagram</h4>
                         <HorizonView
                             observerAngle={this.state.observerAngle}
-                            moonObserverPos={this.state.moonObserverPos}
+                            moonAngle={this.state.moonAngle}
                             showAngle={this.state.showAngle} />
                     </div>
                 </div>
@@ -206,14 +204,14 @@ class LunarPhaseSim extends React.Component {
         }
         return newAngle;
     }
-    incrementMoonPhaseAngle(n, inc) {
+    incrementMoonAngleAngle(n, inc) {
         const newAngle = n + inc;
         if (newAngle > Math.PI) {
             return newAngle - Math.PI * 2;
         }
         return newAngle;
     }
-    decrementMoonPhaseAngle(n, dec) {
+    decrementMoonAngleAngle(n, dec) {
         const newAngle = n - dec;
         if (newAngle < -Math.PI) {
             return newAngle + Math.PI * 2;
@@ -226,11 +224,9 @@ class LunarPhaseSim extends React.Component {
             observerAngle: me.incrementAngle(
                 prevState.observerAngle,
                 0.03 * this.state.animationRate),
-            moonPhase: me.incrementMoonPhaseAngle(
-                prevState.moonPhase,
-                0.001 * this.state.animationRate),
-            moonObserverPos: me.getMoonObserverPos(
-                prevState.observerAngle, prevState.moonPhase)
+            moonAngle: me.incrementMoonAngleAngle(
+                prevState.moonAngle,
+                0.001 * this.state.animationRate)
         }));
         this.raf = requestAnimationFrame(this.animate.bind(this));
     }
@@ -254,17 +250,14 @@ class LunarPhaseSim extends React.Component {
         cancelAnimationFrame(this.raf);
         this.setState({
             isPlaying: false,
-            moonPhase: newAngle,
-            moonObserverPos: newAngle
+            moonAngle: newAngle
         });
     }
-    onMoonPhaseUpdate(newPhase) {
+    onMoonAngleUpdate(newPhase) {
         cancelAnimationFrame(this.raf);
         this.setState({
             isPlaying: false,
-            moonPhase: newPhase,
-            moonObserverPos: this.getMoonObserverPos(
-                this.state.observerAngle, newPhase)
+            moonAngle: newPhase
         });
     }
     onAnimationRateChange(e) {
@@ -272,74 +265,68 @@ class LunarPhaseSim extends React.Component {
             animationRate: forceNumber(e.target.value)
         });
     }
-    getMoonObserverPos(observerAngle, moonPhase) {
-        return observerAngle + Math.PI - moonPhase;
+    getMoonObserverPos(observerAngle, moonAngle) {
+        return observerAngle + Math.PI - moonAngle;
     }
     // TODO: can probably refactor this into something better
     onDecrementDay() {
         const observerAngle = this.decrementAngle(
             this.state.observerAngle, degToRad(360));
-        const moonPhase = this.decrementMoonPhaseAngle(
-            this.state.moonPhase, 0.1);
+        const moonAngle = this.decrementMoonAngleAngle(
+            this.state.moonAngle, 0.1);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     onIncrementDay() {
         const observerAngle = this.incrementAngle(
             this.state.observerAngle, degToRad(360));
-        const moonPhase = this.incrementMoonPhaseAngle(
-            this.state.moonPhase, 0.1);
+        const moonAngle = this.incrementMoonAngleAngle(
+            this.state.moonAngle, 0.1);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     onDecrementHour() {
         const observerAngle = this.decrementAngle(
             this.state.observerAngle, degToRad(360 / 24));
-        const moonPhase = this.decrementMoonPhaseAngle(
-            this.state.moonPhase, 0.01);
+        const moonAngle = this.decrementMoonAngleAngle(
+            this.state.moonAngle, 0.01);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     onIncrementHour() {
         const observerAngle = this.incrementAngle(
             this.state.observerAngle, degToRad(360 / 24));
-        const moonPhase = this.incrementMoonPhaseAngle(
-            this.state.moonPhase, 0.01);
+        const moonAngle = this.incrementMoonAngleAngle(
+            this.state.moonAngle, 0.01);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     onDecrementMinute() {
         const observerAngle = this.decrementAngle(
             this.state.observerAngle, degToRad(360 / 24 / 60));
-        const moonPhase = this.decrementMoonPhaseAngle(
-            this.state.moonPhase, 0.001);
+        const moonAngle = this.decrementMoonAngleAngle(
+            this.state.moonAngle, 0.001);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     onIncrementMinute() {
         const observerAngle = this.incrementAngle(
             this.state.observerAngle, degToRad(360 / 24 / 60));
-        const moonPhase = this.incrementMoonPhaseAngle(
-            this.state.moonPhase, 0.001);
+        const moonAngle = this.incrementMoonAngleAngle(
+            this.state.moonAngle, 0.001);
         this.setState({
             observerAngle: observerAngle,
-            moonPhase: moonPhase,
-            moonObserverPos: this.getMoonObserverPos(observerAngle, moonPhase)
+            moonAngle: moonAngle
         });
     }
     handleInputChange(event) {


### PR DESCRIPTION
tl;dr: This fixes a bug where, when you drag the moon in the "Main View" on the, its position in the 3d horizon view is incorrect.


I got rid of the moonObserverPos state: It's confusing and unnecessary.
Only two pieces of data are needed to display the global scene:
* observerAngle (Sun position. This is the rotation of the earth)
* moonAngle (The moon's phase, shown as the orbit circle on MainView)

Note that in the Horizon Diagram, the moon's position isn't the same as
moonAngle. The moon needs to follow along the sun and slowly lag behind
it. That's why I made moonObserverPos in the first place, but it
shouldn't be a global state variable.. instead, it can just be derived
from moonAngle and observerAngle in this scene.