### PR TITLE
implement analemma - closes #83

### DIFF
--- a/sun-motion-simulator/src/main.jsx
+++ b/sun-motion-simulator/src/main.jsx
@@ -37,7 +37,10 @@ class SunMotionSim extends React.Component {
             showEcliptic: true,
             showMonthLabels: false,
             showUnderside: true,
-            showStickfigure: true
+            showStickfigure: true,
+
+            // Advanced
+            showAnalemma: false
         };
         this.state = this.initialState;
 
@@ -115,6 +118,7 @@ class SunMotionSim extends React.Component {
                         showMonthLabels={this.state.showMonthLabels}
                         showStickfigure={this.state.showStickfigure}
                         showUnderside={this.state.showUnderside}
+                        showAnalemma={this.state.showAnalemma}
                         sunAzimuth={this.state.sunAzimuth}
                         sunDeclination={this.state.sunDeclination} />
                     <div>
@@ -137,8 +141,9 @@ class SunMotionSim extends React.Component {
                                     </div>
                                     <div className="custom-control custom-checkbox">
                                         <input type="checkbox" className="custom-control-input"
-                                               name="showAngle"
-                                               id="showAnalemma" />
+                                               onChange={this.handleInputChange}
+                                               checked={this.state.showAnalemma}
+                                               name="showAnalemma" id="showAnalemma" />
                                         <label className="custom-control-label"
                                                htmlFor="showAnalemma">
                                             Show analemma

--- a/sun-motion-simulator/src/utils.js
+++ b/sun-motion-simulator/src/utils.js
@@ -125,11 +125,41 @@ const formatHours = function(n) {
     return `${negDisplay}${hours}h ${minutes}m`;
 }
 
+// https://gist.github.com/chris-siedell/b5de8dae41cfa8a5ad67a1501aeeab47
+const getEqnOfTime = function(day) {
+    // this function returns the equation of time in radians
+    const sin = Math.sin;
+    const cos = Math.cos;
+    return (-4.3796019e-6
+            + 0.001830724*cos(0.017214206*day) - 0.032070267*sin(0.017214206*day)
+            - 0.015952904*cos(0.034428413*day) - 0.04026479*sin(0.034428413*day)
+            - 0.00044373354*cos(0.051642619*day) - 0.0013114725*sin(0.051642619*day)
+            - 0.00064591583*cos(0.068856825*day) - 0.00070547099*sin(0.068856825*day));
+}
+
+// https://gist.github.com/chris-siedell/b5de8dae41cfa8a5ad67a1501aeeab47
+const getPosition = function(day) {
+    // this function returns the right ascension in decimal hours and
+    // the declination in degrees
+    const sin = Math.sin;
+    const cos = Math.cos;
+    var ra = 0.01721421*day - 1.3793756
+            - 0.001830724*cos(0.017214206*day) + 0.032070267*sin(0.017214206*day)
+            + 0.015952904*cos(0.034428413*day) + 0.04026479*sin(0.034428413*day)
+            + 0.00044373354*cos(0.051642619*day) + 0.0013114725*sin(0.051642619*day)
+            + 0.00064591583*cos(0.068856825*day) + 0.00070547099*sin(0.068856825*day);
+    var obj = {};
+    obj.ra = (((12/Math.PI)*ra)%24+24)%24;
+    obj.dec = (180/Math.PI)*Math.atan2(sin(ra), 2.30644456403329);
+    return obj;
+}
+
 export {
     forceNumber, roundToOnePlace, timeToAngle,
     hourAngleToTime, minuteAngleToTime,
     degToRad, radToDeg,
     getSunAltitude,
     getRightAscension, getSiderealTime,
-    getDayOfYear, formatMinutes, formatHours
+    getDayOfYear, formatMinutes, formatHours,
+    getEqnOfTime, getPosition
 };


### PR DESCRIPTION
Well this took a long time. And then it just worked and everything's in
place all of a sudden, after figuring out how to render the original
author's analemma function in Three.js.

https://gist.github.com/chris-siedell/b5de8dae41cfa8a5ad67a1501aeeab47#file-analemma-as-L52

Now I need to fix an issue with the sun's movement: its declination
moves it up and down correctly along the analemma, but it needs to move
slightly forward and backward as well over the course of the year to follow
the figure-eight.

You turn on the analemma with the Show Analemma checkbox.

![2018-10-12-135405_253x276_scrot](https://user-images.githubusercontent.com/59292/46885665-a65d1f80-ce26-11e8-8c6a-a02f8cd9ecfd.png)
