### PR TITLE
Fix moon angle bugs - closes #149, closes #148

### DIFF
--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -243,7 +243,7 @@ export default class HorizonView extends React.Component {
 
         this.skyMaterial = new THREE.MeshBasicMaterial({
             transparent: true,
-            opacity: 0.8,            
+            opacity: 0.8,
             color: this.dayColor,
             // Don't shade the green plane within the dome
             side: THREE.BackSide
@@ -557,9 +557,13 @@ export default class HorizonView extends React.Component {
 
             const angle = Math.atan2(closestPoint.y, closestPoint.x);
             if (this.state.isDraggingSun) {
+                const diff = this.props.observerAngle - angle;
+                this.props.onMoonAngleUpdate(
+                    (this.props.moonAngle - diff) % (Math.PI * 2));
                 return this.props.onObserverAngleUpdate(angle);
             } else if (this.state.isDraggingMoon) {
-                return this.props.onMoonAngleUpdate(-angle - Math.PI / 2);
+                return this.props.onMoonAngleUpdate(
+                    -angle - (Math.PI / 2));
             }
         }
 

--- a/lunar-phase-simulator/src/MainView.jsx
+++ b/lunar-phase-simulator/src/MainView.jsx
@@ -188,7 +188,9 @@ export default class MainView extends React.Component {
         g.beginFill(0xffe200, 0.7);
         g.arc(this.orbitCenter.x, this.orbitCenter.y,
               200,
-              Math.PI, -moonAngle, moonAngle < 0);
+              Math.PI, -moonAngle,
+              // counter-clockwise?
+              moonAngle < 0 && moonAngle > -Math.PI);
 
         g.lineTo(this.orbitCenter.x, this.orbitCenter.y);
         g.lineTo(170, 230);

--- a/lunar-phase-simulator/src/main.jsx
+++ b/lunar-phase-simulator/src/main.jsx
@@ -250,11 +250,11 @@ class LunarPhaseSim extends React.Component {
             observerAngle: newAngle
         });
     }
-    onMoonAngleUpdate(newPhase) {
+    onMoonAngleUpdate(newAngle) {
         cancelAnimationFrame(this.raf);
         this.setState({
             isPlaying: false,
-            moonAngle: newPhase
+            moonAngle: newAngle
         });
     }
     onAnimationRateChange(e) {


### PR DESCRIPTION
* Prevent "show angle" feature from showing an angle greater than 180
  degrees
* When dragging sun in HorizonView, moonAngle should update as well,
  causing the moon to stay in place in HorizonView while moving with
  earth's rotation in MainView, just like the original simulation.