### PR TITLE
Lunar phase moon dragging fix

### DIFF
--- a/lunar-phase-simulator/src/HorizonView.jsx
+++ b/lunar-phase-simulator/src/HorizonView.jsx
@@ -568,8 +568,15 @@ export default class HorizonView extends React.Component {
                     (this.props.moonAngle - diff) % (Math.PI * 2));
                 return this.props.onObserverAngleUpdate(angle);
             } else if (this.state.isDraggingMoon) {
-                return this.props.onMoonAngleUpdate(
-                    -angle - (Math.PI / 2));
+                let moonAngle = -angle + this.props.observerAngle + Math.PI;
+
+                if (moonAngle < -Math.PI) {
+                    moonAngle += Math.PI * 2;
+                } else if (moonAngle > Math.PI) {
+                    moonAngle -= Math.PI * 2;
+                }
+
+                return this.props.onMoonAngleUpdate(moonAngle);
             }
         }
 


### PR DESCRIPTION
This fixes a bug where the moon phase is sometimes not displayed
correctly when dragging the moon on the HorizonView.

This just makes sure the format of moonAngle is the same when the moon
is dragged on both the MainView and the HorizonView.